### PR TITLE
Unique CharacterPair Picker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,8 +147,11 @@ mod tests {
     #[test]
     fn letter_pair_error_from() {
         let message = String::from("cats are great.");
-        let error =
-            solvers::SolverError::new(message.clone(), solvers::ErrorKind::ConsistencyError, None);
+        let error = solvers::SolverError::new(
+            message.clone(),
+            solvers::ErrorKind::ModelConsistencyError,
+            None,
+        );
         assert_eq!(message, format!("{:?}", LetterPairsError::from(error)));
     }
 

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -240,16 +240,16 @@ mod tests {
         let model = Model::build_test_model("cat abs hutch oven cab cap much coven");
         let solution = create_test_solution(&model, vec!["cat", "abs", "oven", "much"]);
         let expected: HashSet<Rc<CharacterPair>> = vec![
-            ('c', 'a'),
-            ('a', 't'),
-            ('a', 'b'),
-            ('b', 's'),
-            ('o', 'v'),
-            ('v', 'e'),
-            ('e', 'n'),
-            ('m', 'u'),
-            ('u', 'c'),
-            ('c', 'h'),
+            CharacterPair::new('c', 'a'),
+            CharacterPair::new('a', 't'),
+            CharacterPair::new('a', 'b'),
+            CharacterPair::new('b', 's'),
+            CharacterPair::new('o', 'v'),
+            CharacterPair::new('v', 'e'),
+            CharacterPair::new('e', 'n'),
+            CharacterPair::new('m', 'u'),
+            CharacterPair::new('u', 'c'),
+            CharacterPair::new('c', 'h'),
         ]
         .into_iter()
         .map(|x| Rc::new(x))
@@ -262,10 +262,14 @@ mod tests {
     fn pairs_duplicates() {
         let model = Model::build_test_model("cat abs hutch oven cab cap much coven");
         let solution = create_test_solution(&model, vec!["cat", "cab"]);
-        let expected: HashSet<Rc<CharacterPair>> = vec![('c', 'a'), ('a', 't'), ('a', 'b')]
-            .into_iter()
-            .map(|x| Rc::new(x))
-            .collect();
+        let expected: HashSet<Rc<CharacterPair>> = vec![
+            CharacterPair::new('c', 'a'),
+            CharacterPair::new('a', 't'),
+            CharacterPair::new('a', 'b'),
+        ]
+        .into_iter()
+        .map(|x| Rc::new(x))
+        .collect();
 
         assert_eq!(solution.pairs(), expected);
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -665,7 +665,7 @@ mod tests {
                 Timing {
                     result: Err(SolverError::new(
                         String::from("test"),
-                        SolverErrorKind::ConsistencyError,
+                        SolverErrorKind::ModelConsistencyError,
                         None,
                     )),
                     duration,
@@ -692,7 +692,7 @@ mod tests {
             let t2 = Timing {
                 result: Err(SolverError::new(
                     String::from("test"),
-                    SolverErrorKind::ConsistencyError,
+                    SolverErrorKind::ModelConsistencyError,
                     None,
                 )),
                 duration,
@@ -1238,7 +1238,7 @@ mod tests {
         fn error_solver(_model: &Model) -> Result<Solution, SolverError> {
             Err(SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             ))
         }
@@ -1262,7 +1262,7 @@ mod tests {
 
             let s3 = SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             );
             let t3_duration = Duration::new(10000, 0);
@@ -1339,7 +1339,7 @@ mod tests {
         fn calculate_stats_all_errors() {
             let s1 = SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             );
             let mut duration = Duration::new(20000, 0);
@@ -1350,7 +1350,7 @@ mod tests {
 
             let s2 = SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             );
             duration = Duration::new(10000, 0);
@@ -1499,7 +1499,7 @@ mod tests {
             let start = Instant::now();
             let error = SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             );
             let duration = start.elapsed();
@@ -1543,7 +1543,7 @@ mod tests {
             let start = Instant::now();
             let error = SolverError::new(
                 String::from("test"),
-                SolverErrorKind::ConsistencyError,
+                SolverErrorKind::ModelConsistencyError,
                 None,
             );
 


### PR DESCRIPTION
Adds a method to `Model` that returns a `HashSet` of `Words` that are distinquished by the fact that they contain a unique `CharacterPair`.
Also reworks the `CharacterPair` from a tuple of characters into a struct with a Display implementation.

Closes #5 